### PR TITLE
chore: enable renovate automerge

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -13,13 +13,15 @@
     ],
     "extends": [
         "config:best-practices",
-        ":automergePatch",
         "schedule:weekends",
-        "schedule:automergeEarlyMondays"
+        ":automergeAll",
+        ":automergePr",
+        ":automergeRequireAllStatusChecks"
     ],
     "dependencyDashboard": true,
     "timezone": "Asia/Tokyo",
     "rangeStrategy": "bump",
+    "automergeStrategy": "squash",
     "assignAutomerge": true,
     "packageRules": [
         {


### PR DESCRIPTION
## 概要

Renovate PR の automerge 設定を更新しました。
CI が通った Renovate PR は、PR として作成されたあと Renovate によって squash merge されます。

## 変更内容

- patch 限定の automerge を全 Renovate 更新に拡張
- 月曜早朝だけの automerge schedule を解除
- status checks の成功を automerge 条件として明示
- automerge の merge strategy を squash に統一

## 確認

- `jq empty .github/renovate.json`
- `git diff --check -- .github/renovate.json`
