### PR TITLE
chore: tighten PHPStan/Larastan and ECS rules

### DIFF
--- a/app/Console/Commands/Sample/AppHealthCheck.php
+++ b/app/Console/Commands/Sample/AppHealthCheck.php
@@ -17,18 +17,8 @@ use RuntimeException;
 
 use function sprintf;
 
-class AppHealthCheck extends Command
+final class AppHealthCheck extends Command
 {
-    public function __construct(
-        private readonly ConnectionInterface $connectionInterface,
-        private readonly FactoryContract $factoryContract,
-        private readonly CacheManager $cacheManager,
-        private readonly Store $store,
-        private readonly MailManager $mailManager,
-    ) {
-        parent::__construct();
-    }
-
     /**
      * The name and signature of the console command.
      *
@@ -44,6 +34,16 @@ class AppHealthCheck extends Command
      */
     #[Override]
     protected $description = 'Command description';
+
+    public function __construct(
+        private readonly ConnectionInterface $connectionInterface,
+        private readonly FactoryContract $factoryContract,
+        private readonly CacheManager $cacheManager,
+        private readonly Store $store,
+        private readonly MailManager $mailManager,
+    ) {
+        parent::__construct();
+    }
 
     /**
      * @throws InvalidArgumentException

--- a/app/Console/Commands/Sample/SampleS3Upload.php
+++ b/app/Console/Commands/Sample/SampleS3Upload.php
@@ -11,14 +11,8 @@ use Override;
 
 use function sprintf;
 
-class SampleS3Upload extends Command
+final class SampleS3Upload extends Command
 {
-    public function __construct(
-        private readonly FactoryContract $filesystem
-    ) {
-        parent::__construct();
-    }
-
     /**
      * The name and signature of the console command.
      *
@@ -34,6 +28,12 @@ class SampleS3Upload extends Command
      */
     #[Override]
     protected $description = 'Command description';
+
+    public function __construct(
+        private readonly FactoryContract $filesystem
+    ) {
+        parent::__construct();
+    }
 
     public function handle(): int
     {

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -7,7 +7,7 @@ namespace App\Console;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
 use Override;
 
-class Kernel extends ConsoleKernel
+final class Kernel extends ConsoleKernel
 {
     #[Override]
     protected function commands(): void

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -8,7 +8,7 @@ use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
 use Override;
 use Throwable;
 
-class Handler extends ExceptionHandler
+final class Handler extends ExceptionHandler
 {
     /**
      * A list of exception types with their corresponding custom log levels.

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -8,9 +8,8 @@ use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Foundation\Validation\ValidatesRequests;
 use Illuminate\Routing\Controller as BaseController;
 
-class Controller extends BaseController
+abstract class Controller extends BaseController
 {
     use AuthorizesRequests;
-
     use ValidatesRequests;
 }

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -29,7 +29,7 @@ use Illuminate\Session\Middleware\StartSession;
 use Illuminate\View\Middleware\ShareErrorsFromSession;
 use Override;
 
-class Kernel extends HttpKernel
+final class Kernel extends HttpKernel
 {
     /**
      * The application's global HTTP middleware stack.

--- a/app/Http/Middleware/Authenticate.php
+++ b/app/Http/Middleware/Authenticate.php
@@ -8,7 +8,7 @@ use Illuminate\Auth\Middleware\Authenticate as Middleware;
 use Illuminate\Http\Request;
 use Override;
 
-class Authenticate extends Middleware
+final class Authenticate extends Middleware
 {
     /**
      * Get the path the user should be redirected to when they are not authenticated.

--- a/app/Http/Middleware/EncryptCookies.php
+++ b/app/Http/Middleware/EncryptCookies.php
@@ -7,7 +7,7 @@ namespace App\Http\Middleware;
 use Illuminate\Cookie\Middleware\EncryptCookies as Middleware;
 use Override;
 
-class EncryptCookies extends Middleware
+final class EncryptCookies extends Middleware
 {
     /**
      * The names of the cookies that should not be encrypted.

--- a/app/Http/Middleware/PreventRequestsDuringMaintenance.php
+++ b/app/Http/Middleware/PreventRequestsDuringMaintenance.php
@@ -7,7 +7,7 @@ namespace App\Http\Middleware;
 use Illuminate\Foundation\Http\Middleware\PreventRequestsDuringMaintenance as Middleware;
 use Override;
 
-class PreventRequestsDuringMaintenance extends Middleware
+final class PreventRequestsDuringMaintenance extends Middleware
 {
     /**
      * The URIs that should be reachable while maintenance mode is enabled.

--- a/app/Http/Middleware/RedirectIfAuthenticated.php
+++ b/app/Http/Middleware/RedirectIfAuthenticated.php
@@ -10,7 +10,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Symfony\Component\HttpFoundation\Response;
 
-class RedirectIfAuthenticated
+final class RedirectIfAuthenticated
 {
     /**
      * Handle an incoming request.

--- a/app/Http/Middleware/TrimStrings.php
+++ b/app/Http/Middleware/TrimStrings.php
@@ -7,7 +7,7 @@ namespace App\Http\Middleware;
 use Illuminate\Foundation\Http\Middleware\TrimStrings as Middleware;
 use Override;
 
-class TrimStrings extends Middleware
+final class TrimStrings extends Middleware
 {
     /**
      * The names of the attributes that should not be trimmed.

--- a/app/Http/Middleware/TrustHosts.php
+++ b/app/Http/Middleware/TrustHosts.php
@@ -7,7 +7,7 @@ namespace App\Http\Middleware;
 use Illuminate\Http\Middleware\TrustHosts as Middleware;
 use Override;
 
-class TrustHosts extends Middleware
+final class TrustHosts extends Middleware
 {
     /**
      * Get the host patterns that should be trusted.

--- a/app/Http/Middleware/TrustProxies.php
+++ b/app/Http/Middleware/TrustProxies.php
@@ -8,7 +8,7 @@ use Illuminate\Http\Middleware\TrustProxies as Middleware;
 use Illuminate\Http\Request;
 use Override;
 
-class TrustProxies extends Middleware
+final class TrustProxies extends Middleware
 {
     /**
      * The trusted proxies for this application.

--- a/app/Http/Middleware/ValidateSignature.php
+++ b/app/Http/Middleware/ValidateSignature.php
@@ -6,7 +6,7 @@ namespace App\Http\Middleware;
 
 use Illuminate\Routing\Middleware\ValidateSignature as Middleware;
 
-class ValidateSignature extends Middleware
+final class ValidateSignature extends Middleware
 {
     /**
      * The names of the query string parameters that should be ignored.

--- a/app/Http/Middleware/VerifyCsrfToken.php
+++ b/app/Http/Middleware/VerifyCsrfToken.php
@@ -7,7 +7,7 @@ namespace App\Http\Middleware;
 use Illuminate\Foundation\Http\Middleware\VerifyCsrfToken as Middleware;
 use Override;
 
-class VerifyCsrfToken extends Middleware
+final class VerifyCsrfToken extends Middleware
 {
     /**
      * The URIs that should be excluded from CSRF verification.

--- a/app/Mail/AppHealthCheck.php
+++ b/app/Mail/AppHealthCheck.php
@@ -10,10 +10,9 @@ use Illuminate\Mail\Mailables\Content;
 use Illuminate\Mail\Mailables\Envelope;
 use Illuminate\Queue\SerializesModels;
 
-class AppHealthCheck extends Mailable
+final class AppHealthCheck extends Mailable
 {
     use Queueable;
-
     use SerializesModels;
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -4,18 +4,15 @@ declare(strict_types=1);
 
 namespace App\Models;
 
-use Illuminate\Database\Eloquent\Factories\Factory;
+use Database\Factories\UserFactory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Override;
 
-/**
- * @template TFactory of Factory
- */
-class User extends Authenticatable
+final class User extends Authenticatable
 {
-    /** @use HasFactory<TFactory> */
+    /** @use HasFactory<UserFactory> */
     use HasFactory;
 
     use Notifiable;

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -11,7 +11,7 @@ use Illuminate\Support\Facades\Date;
 use Illuminate\Support\ServiceProvider;
 use Override;
 
-class AppServiceProvider extends ServiceProvider
+final class AppServiceProvider extends ServiceProvider
 {
     /**
      * Register any application services.

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -7,7 +7,7 @@ namespace App\Providers;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
 use Override;
 
-class AuthServiceProvider extends ServiceProvider
+final class AuthServiceProvider extends ServiceProvider
 {
     /**
      * The model to policy mappings for the application.
@@ -18,12 +18,4 @@ class AuthServiceProvider extends ServiceProvider
     protected $policies = [
         // 'App\Models\Model' => 'App\Policies\ModelPolicy',
     ];
-
-    /**
-     * Register any authentication / authorization services.
-     */
-    public function boot(): void
-    {
-
-    }
 }

--- a/app/Providers/BroadcastServiceProvider.php
+++ b/app/Providers/BroadcastServiceProvider.php
@@ -7,7 +7,7 @@ namespace App\Providers;
 use Illuminate\Support\Facades\Broadcast;
 use Illuminate\Support\ServiceProvider;
 
-class BroadcastServiceProvider extends ServiceProvider
+final class BroadcastServiceProvider extends ServiceProvider
 {
     /**
      * Bootstrap any application services.

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -9,7 +9,7 @@ use Illuminate\Auth\Listeners\SendEmailVerificationNotification;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
 use Override;
 
-class EventServiceProvider extends ServiceProvider
+final class EventServiceProvider extends ServiceProvider
 {
     /**
      * @inheritDoc

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -11,14 +11,14 @@ use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Facades\Route;
 use Override;
 
-class RouteServiceProvider extends ServiceProvider
+final class RouteServiceProvider extends ServiceProvider
 {
     /**
      * The path to the "home" route for your application.
      *
      * Typically, users are redirected here after authentication.
      */
-    final public const string HOME = '/home';
+    public const string HOME = '/home';
 
     /**
      * Define your route model bindings, pattern filters, and other route configuration.

--- a/libConfig/ecs.php
+++ b/libConfig/ecs.php
@@ -2,64 +2,121 @@
 
 declare(strict_types=1);
 
+use PhpCsFixer\Fixer\Alias\NoAliasLanguageConstructCallFixer;
 use PhpCsFixer\Fixer\ArrayNotation\ArraySyntaxFixer;
 use PhpCsFixer\Fixer\ArrayNotation\NoMultilineWhitespaceAroundDoubleArrowFixer;
 use PhpCsFixer\Fixer\ArrayNotation\NoWhitespaceBeforeCommaInArrayFixer;
 use PhpCsFixer\Fixer\ArrayNotation\WhitespaceAfterCommaInArrayFixer;
 use PhpCsFixer\Fixer\Basic\BracesPositionFixer;
+use PhpCsFixer\Fixer\Basic\NoMultipleStatementsPerLineFixer;
 use PhpCsFixer\Fixer\Basic\NoTrailingCommaInSinglelineFixer;
+use PhpCsFixer\Fixer\Casing\NativeTypeDeclarationCasingFixer;
+use PhpCsFixer\Fixer\ClassNotation\ClassAttributesSeparationFixer;
+use PhpCsFixer\Fixer\ClassNotation\ClassDefinitionFixer;
+use PhpCsFixer\Fixer\ClassNotation\FinalClassFixer;
 use PhpCsFixer\Fixer\ClassNotation\NoBlankLinesAfterClassOpeningFixer;
+use PhpCsFixer\Fixer\ClassNotation\NoNullPropertyInitializationFixer;
+use PhpCsFixer\Fixer\ClassNotation\OrderedClassElementsFixer;
 use PhpCsFixer\Fixer\ClassNotation\OrderedTraitsFixer;
+use PhpCsFixer\Fixer\ClassNotation\OrderedTypesFixer;
+use PhpCsFixer\Fixer\ClassNotation\ProtectedToPrivateFixer;
+use PhpCsFixer\Fixer\ClassNotation\SelfStaticAccessorFixer;
+use PhpCsFixer\Fixer\ClassNotation\SingleClassElementPerStatementFixer;
 use PhpCsFixer\Fixer\ClassNotation\SingleTraitInsertPerStatementFixer;
+use PhpCsFixer\Fixer\Comment\MultilineCommentOpeningClosingFixer;
 use PhpCsFixer\Fixer\Comment\NoEmptyCommentFixer;
 use PhpCsFixer\Fixer\Comment\SingleLineCommentSpacingFixer;
 use PhpCsFixer\Fixer\ControlStructure\ElseifFixer;
 use PhpCsFixer\Fixer\ControlStructure\NoBreakCommentFixer;
 use PhpCsFixer\Fixer\ControlStructure\NoSuperfluousElseifFixer;
+use PhpCsFixer\Fixer\ControlStructure\NoUnneededBracesFixer;
+use PhpCsFixer\Fixer\ControlStructure\NoUnneededControlParenthesesFixer;
+use PhpCsFixer\Fixer\ControlStructure\NoUselessElseFixer;
+use PhpCsFixer\Fixer\ControlStructure\SimplifiedIfReturnFixer;
+use PhpCsFixer\Fixer\ControlStructure\SwitchContinueToBreakFixer;
 use PhpCsFixer\Fixer\ControlStructure\TrailingCommaInMultilineFixer;
 use PhpCsFixer\Fixer\ControlStructure\YodaStyleFixer;
 use PhpCsFixer\Fixer\FunctionNotation\FunctionDeclarationFixer;
+use PhpCsFixer\Fixer\FunctionNotation\LambdaNotUsedImportFixer;
 use PhpCsFixer\Fixer\FunctionNotation\MethodArgumentSpaceFixer;
+use PhpCsFixer\Fixer\FunctionNotation\NullableTypeDeclarationForDefaultNullValueFixer;
 use PhpCsFixer\Fixer\FunctionNotation\ReturnTypeDeclarationFixer;
 use PhpCsFixer\Fixer\FunctionNotation\StaticLambdaFixer;
+use PhpCsFixer\Fixer\FunctionNotation\UseArrowFunctionsFixer;
 use PhpCsFixer\Fixer\FunctionNotation\VoidReturnFixer;
 use PhpCsFixer\Fixer\Import\FullyQualifiedStrictTypesFixer;
 use PhpCsFixer\Fixer\Import\GlobalNamespaceImportFixer;
+use PhpCsFixer\Fixer\Import\NoUnneededImportAliasFixer;
 use PhpCsFixer\Fixer\Import\NoUnusedImportsFixer;
 use PhpCsFixer\Fixer\Import\OrderedImportsFixer;
+use PhpCsFixer\Fixer\LanguageConstruct\CombineConsecutiveIssetsFixer;
+use PhpCsFixer\Fixer\LanguageConstruct\CombineConsecutiveUnsetsFixer;
+use PhpCsFixer\Fixer\LanguageConstruct\ExplicitIndirectVariableFixer;
 use PhpCsFixer\Fixer\LanguageConstruct\IsNullFixer;
 use PhpCsFixer\Fixer\ListNotation\ListSyntaxFixer;
 use PhpCsFixer\Fixer\NamespaceNotation\BlankLinesBeforeNamespaceFixer;
+use PhpCsFixer\Fixer\NamespaceNotation\CleanNamespaceFixer;
 use PhpCsFixer\Fixer\NamespaceNotation\NoLeadingNamespaceWhitespaceFixer;
+use PhpCsFixer\Fixer\Operator\AssignNullCoalescingToCoalesceEqualFixer;
 use PhpCsFixer\Fixer\Operator\BinaryOperatorSpacesFixer;
+use PhpCsFixer\Fixer\Operator\NoUselessConcatOperatorFixer;
+use PhpCsFixer\Fixer\Operator\NoUselessNullsafeOperatorFixer;
+use PhpCsFixer\Fixer\Operator\StandardizeIncrementFixer;
+use PhpCsFixer\Fixer\Operator\TernaryToElvisOperatorFixer;
+use PhpCsFixer\Fixer\Operator\TernaryToNullCoalescingFixer;
 use PhpCsFixer\Fixer\Phpdoc\AlignMultilineCommentFixer;
 use PhpCsFixer\Fixer\Phpdoc\GeneralPhpdocAnnotationRemoveFixer;
 use PhpCsFixer\Fixer\Phpdoc\NoBlankLinesAfterPhpdocFixer;
 use PhpCsFixer\Fixer\Phpdoc\NoEmptyPhpdocFixer;
 use PhpCsFixer\Fixer\Phpdoc\NoSuperfluousPhpdocTagsFixer;
 use PhpCsFixer\Fixer\Phpdoc\PhpdocAlignFixer;
+use PhpCsFixer\Fixer\Phpdoc\PhpdocArrayTypeFixer;
+use PhpCsFixer\Fixer\Phpdoc\PhpdocIndentFixer;
+use PhpCsFixer\Fixer\Phpdoc\PhpdocLineSpanFixer;
+use PhpCsFixer\Fixer\Phpdoc\PhpdocListTypeFixer;
 use PhpCsFixer\Fixer\Phpdoc\PhpdocNoPackageFixer;
+use PhpCsFixer\Fixer\Phpdoc\PhpdocNoUselessInheritdocFixer;
+use PhpCsFixer\Fixer\Phpdoc\PhpdocOrderFixer;
+use PhpCsFixer\Fixer\Phpdoc\PhpdocParamOrderFixer;
+use PhpCsFixer\Fixer\Phpdoc\PhpdocReturnSelfReferenceFixer;
+use PhpCsFixer\Fixer\Phpdoc\PhpdocScalarFixer;
+use PhpCsFixer\Fixer\Phpdoc\PhpdocSeparationFixer;
+use PhpCsFixer\Fixer\Phpdoc\PhpdocSingleLineVarSpacingFixer;
+use PhpCsFixer\Fixer\Phpdoc\PhpdocTrimConsecutiveBlankLineSeparationFixer;
+use PhpCsFixer\Fixer\Phpdoc\PhpdocTrimFixer;
+use PhpCsFixer\Fixer\Phpdoc\PhpdocTypesFixer;
+use PhpCsFixer\Fixer\Phpdoc\PhpdocTypesOrderFixer;
+use PhpCsFixer\Fixer\Phpdoc\PhpdocVarWithoutNameFixer;
 use PhpCsFixer\Fixer\PhpTag\BlankLineAfterOpeningTagFixer;
 use PhpCsFixer\Fixer\PhpTag\LinebreakAfterOpeningTagFixer;
+use PhpCsFixer\Fixer\PhpUnit\PhpUnitAttributesFixer;
 use PhpCsFixer\Fixer\PhpUnit\PhpUnitDataProviderNameFixer;
 use PhpCsFixer\Fixer\PhpUnit\PhpUnitDataProviderReturnTypeFixer;
+use PhpCsFixer\Fixer\PhpUnit\PhpUnitFqcnAnnotationFixer;
+use PhpCsFixer\Fixer\PhpUnit\PhpUnitMethodCasingFixer;
+use PhpCsFixer\Fixer\PhpUnit\PhpUnitSetUpTearDownVisibilityFixer;
 use PhpCsFixer\Fixer\PhpUnit\PhpUnitStrictFixer;
-use PhpCsFixer\Fixer\PhpUnit\PhpUnitTestAnnotationFixer;
 use PhpCsFixer\Fixer\PhpUnit\PhpUnitTestCaseStaticMethodCallsFixer;
+use PhpCsFixer\Fixer\ReturnNotation\NoUselessReturnFixer;
+use PhpCsFixer\Fixer\ReturnNotation\SimplifiedNullReturnFixer;
 use PhpCsFixer\Fixer\Semicolon\MultilineWhitespaceBeforeSemicolonsFixer;
 use PhpCsFixer\Fixer\Semicolon\NoEmptyStatementFixer;
 use PhpCsFixer\Fixer\Strict\StrictComparisonFixer;
 use PhpCsFixer\Fixer\Strict\StrictParamFixer;
+use PhpCsFixer\Fixer\StringNotation\ExplicitStringVariableFixer;
 use PhpCsFixer\Fixer\StringNotation\SimpleToComplexStringVariableFixer;
 use PhpCsFixer\Fixer\StringNotation\SingleQuoteFixer;
 use PhpCsFixer\Fixer\Whitespace\ArrayIndentationFixer;
 use PhpCsFixer\Fixer\Whitespace\BlankLineBeforeStatementFixer;
 use PhpCsFixer\Fixer\Whitespace\BlankLineBetweenImportGroupsFixer;
 use PhpCsFixer\Fixer\Whitespace\CompactNullableTypeDeclarationFixer;
+use PhpCsFixer\Fixer\Whitespace\HeredocIndentationFixer;
+use PhpCsFixer\Fixer\Whitespace\MethodChainingIndentationFixer;
 use PhpCsFixer\Fixer\Whitespace\NoExtraBlankLinesFixer;
 use PhpCsFixer\Fixer\Whitespace\NoWhitespaceInBlankLineFixer;
 use PhpCsFixer\Fixer\Whitespace\SingleBlankLineAtEofFixer;
 use PhpCsFixer\Fixer\Whitespace\StatementIndentationFixer;
+use PhpCsFixer\Fixer\Whitespace\TypesSpacesFixer;
 use Symplify\CodingStandard\Fixer\Spacing\SpaceAfterCommaHereNowDocFixer;
 use Symplify\EasyCodingStandard\Config\ECSConfig;
 
@@ -154,8 +211,12 @@ return ECSConfig::configure()
         ],
     )
     ->withConfiguredRule(
-        PhpUnitTestAnnotationFixer::class,
-        ['style' => 'annotation']
+        OrderedTypesFixer::class,
+        ['null_adjustment' => 'always_last'],
+    )
+    ->withConfiguredRule(
+        PhpdocTypesOrderFixer::class,
+        ['null_adjustment' => 'always_last'],
     )
     ->withConfiguredRule(
         BracesPositionFixer::class,
@@ -240,6 +301,62 @@ return ECSConfig::configure()
         BlankLineAfterOpeningTagFixer::class,
         SpaceAfterCommaHereNowDocFixer::class,
         WhitespaceAfterCommaInArrayFixer::class,
+        FinalClassFixer::class,
+        ProtectedToPrivateFixer::class,
+        SelfStaticAccessorFixer::class,
+        OrderedClassElementsFixer::class,
+        ClassAttributesSeparationFixer::class,
+        NoNullPropertyInitializationFixer::class,
+        SingleClassElementPerStatementFixer::class,
+        ClassDefinitionFixer::class,
+        NoUselessElseFixer::class,
+        SimplifiedIfReturnFixer::class,
+        NoUnneededControlParenthesesFixer::class,
+        NoUnneededBracesFixer::class,
+        SwitchContinueToBreakFixer::class,
+        NoUselessReturnFixer::class,
+        SimplifiedNullReturnFixer::class,
+        NullableTypeDeclarationForDefaultNullValueFixer::class,
+        UseArrowFunctionsFixer::class,
+        LambdaNotUsedImportFixer::class,
+        TypesSpacesFixer::class,
+        HeredocIndentationFixer::class,
+        MethodChainingIndentationFixer::class,
+        PhpdocScalarFixer::class,
+        PhpdocTypesFixer::class,
+        PhpdocOrderFixer::class,
+        PhpdocSeparationFixer::class,
+        PhpdocTrimFixer::class,
+        PhpdocIndentFixer::class,
+        PhpdocArrayTypeFixer::class,
+        PhpdocListTypeFixer::class,
+        PhpdocVarWithoutNameFixer::class,
+        PhpdocReturnSelfReferenceFixer::class,
+        PhpdocNoUselessInheritdocFixer::class,
+        PhpdocTrimConsecutiveBlankLineSeparationFixer::class,
+        PhpdocSingleLineVarSpacingFixer::class,
+        PhpdocParamOrderFixer::class,
+        PhpdocLineSpanFixer::class,
+        AssignNullCoalescingToCoalesceEqualFixer::class,
+        TernaryToNullCoalescingFixer::class,
+        NoUselessConcatOperatorFixer::class,
+        NoUselessNullsafeOperatorFixer::class,
+        StandardizeIncrementFixer::class,
+        TernaryToElvisOperatorFixer::class,
+        ExplicitStringVariableFixer::class,
+        ExplicitIndirectVariableFixer::class,
+        CombineConsecutiveIssetsFixer::class,
+        CombineConsecutiveUnsetsFixer::class,
+        NoAliasLanguageConstructCallFixer::class,
+        PhpUnitAttributesFixer::class,
+        PhpUnitMethodCasingFixer::class,
+        PhpUnitSetUpTearDownVisibilityFixer::class,
+        PhpUnitFqcnAnnotationFixer::class,
+        NativeTypeDeclarationCasingFixer::class,
+        CleanNamespaceFixer::class,
+        NoUnneededImportAliasFixer::class,
+        NoMultipleStatementsPerLineFixer::class,
+        MultilineCommentOpeningClosingFixer::class,
     ])
     // modify parallel run
     ->withParallel(timeoutSeconds: 120, maxNumberOfProcess: 32, jobSize: 20);

--- a/libConfig/phpstan.neon
+++ b/libConfig/phpstan.neon
@@ -16,3 +16,26 @@ parameters:
   tmpDir: ../.tempCache/.stan
   strictRules:
     allRules: true
+  checkBenevolentUnionTypes: true
+  checkUninitializedProperties: true
+  checkTooWideReturnTypesInProtectedAndPublicMethods: true
+  checkMissingCallableSignature: true
+  checkMissingOverrideMethodAttribute: true
+  checkImplicitMixed: true
+  reportPossiblyNonexistentGeneralArrayOffset: true
+  reportPossiblyNonexistentConstantArrayOffset: true
+  reportAnyTypeWideningInVarTag: true
+  # Larastan
+  checkOctaneCompatibility: true
+  noUnnecessaryEnumerableToArrayCalls: true
+  checkModelProperties: true
+  checkModelMethodVisibility: true
+  checkConfigTypes: true
+  checkAuthCallsWhenInRequestScope: true
+  parseModelCastsMethod: true
+  checkUnusedViews: true
+  checkMissingTranslations: true
+  configDirectories:
+    - ../config
+  viewDirectories:
+    - ../resources/views

--- a/packages/Samples/HomeController.php
+++ b/packages/Samples/HomeController.php
@@ -14,7 +14,7 @@ use Psr\Log\LoggerInterface;
 use function assert;
 use function is_string;
 
-class HomeController
+final class HomeController
 {
     public function home(
         Repository $config,

--- a/packages/Samples/Sample.php
+++ b/packages/Samples/Sample.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace LaravelOrbStack\Samples;
 
-class Sample
+final class Sample
 {
     public function sample(): string
     {

--- a/packages/Samples/Test/SampleControllerTest.php
+++ b/packages/Samples/Test/SampleControllerTest.php
@@ -7,7 +7,7 @@ namespace LaravelOrbStack\Samples\Test;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
-class SampleControllerTest extends TestCase
+final class SampleControllerTest extends TestCase
 {
     #[Test]
     public function エンドポイントにアクセスすると200になる(): void

--- a/packages/Samples/Test/SampleTest.php
+++ b/packages/Samples/Test/SampleTest.php
@@ -9,7 +9,7 @@ use Override;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
-class SampleTest extends TestCase
+final class SampleTest extends TestCase
 {
     #[Override]
     public static function setUpBeforeClass(): void

--- a/public/index.php
+++ b/public/index.php
@@ -55,7 +55,7 @@ assert($app instanceof Application, Application::class . 'is required.');
 try {
     $kernel = $app->make(Kernel::class);
 } catch (BindingResolutionException) {
-    die('kernel binding failed');
+    exit('kernel binding failed');
 }
 
 $response = $kernel->handle(

--- a/tests/SetUpTest.php
+++ b/tests/SetUpTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests;
 
+use Override;
 use PHPUnit\Event\Application\Started;
 use PHPUnit\Event\Application\StartedSubscriber;
 use PHPUnit\Runner\Extension\Extension as PhpunitExtension;
@@ -13,6 +14,7 @@ use PHPUnit\TextUI\Configuration\Configuration;
 
 final class SetUpTest implements PhpunitExtension
 {
+    #[Override]
     public function bootstrap(
         Configuration $configuration,
         Facade $facade,
@@ -27,6 +29,7 @@ final class SetUpTest implements PhpunitExtension
     {
         return new class() implements StartedSubscriber
         {
+            #[Override]
             public function notify(Started $event): void
             {
                 echo shell_exec('DB_SCHEMA=test php artisan db:wipe');


### PR DESCRIPTION
## 概要

来たる開発に向けて静的解析とコードスタイルの締め付けを一段上げる。現行コードで計測し、追加コストが最小のものだけを有効化した。

## PHPStan / Larastan（`libConfig/phpstan.neon`）

- 追加: `checkImplicitMixed`, `checkBenevolentUnionTypes`, `checkTooWideReturnTypesInProtectedAndPublicMethods`, `checkUninitializedProperties`, `checkMissingCallableSignature`, `checkMissingOverrideMethodAttribute`, `reportPossiblyNonexistent{General,Constant}ArrayOffset`, `reportAnyTypeWideningInVarTag`
- Larastan: `checkModelProperties`, `checkModelMethodVisibility`, `checkConfigTypes`, `checkAuthCallsWhenInRequestScope`, `checkOctaneCompatibility`, `noUnnecessaryEnumerableToArrayCalls`, `parseModelCastsMethod`, `checkUnusedViews`, `checkMissingTranslations` + `configDirectories` / `viewDirectories`
- 見送り: `generalizeEnvReturnType`（`env()` の型を広げる緩和側の設定で、既存の `assert(is_string())` パターンと衝突して 12 件出る）

必要になった修正: `User` の誤った `@template TFactory` を `@use HasFactory<UserFactory>` に、`SetUpTest` に `#[Override]` 2 件。

## ECS（`libConfig/ecs.php`）

- `FinalClassFixer` / `ProtectedToPrivateFixer` / `SelfStaticAccessorFixer`: 具象クラスは全て `final`。基底の `App\Http\Controllers\Controller` は `abstract` に変更
- `OrderedClassElementsFixer` / `ClassAttributesSeparationFixer`: プロパティ → コンストラクタ → メソッドの順に固定
- `OrderedTypesFixer` / `PhpdocTypesOrderFixer`（`null_adjustment: always_last`）: `string|null` の並びを既存コードに合わせて固定
- `PhpdocArrayTypeFixer` / `PhpdocListTypeFixer` ほか phpdoc 系、`NoUselessElse/Return`、`SimplifiedNullReturn`、`UseArrowFunctions`、`NullableTypeDeclarationForDefaultNullValue` など計 56 ルール
- `PhpUnitTestAnnotationFixer`（アノテーション前提、PHPUnit 12+ で無効）を削除し `PhpUnitAttributesFixer` に置換

`final` 化に伴い Rector の dead-code ルールが `AuthServiceProvider::boot()`（空）の削除と `RouteServiceProvider::HOME` の冗長な `final` 除去を行っている。

## 検証

- `phpstan analyze`: No errors
- `ecs check`: No errors
- `rector --dry-run`: 変更なし
- `deptrac`: Violations 0
- `task phpunit`: OK (2 tests, 2 assertions)

## スコープ外（別 PR 候補）

- `phpstan/phpstan-doctrine` と `phpstan/phpstan-nette` は Laravel では未使用。`phpstan/phpstan-deprecation-rules` は未導入
- `withPhpCsFixerSets(psr2: true)` を `perCS30: true` に上げる（差分未計測）